### PR TITLE
Certification: replace Server 2019 gate with Docker Desktop Windows

### DIFF
--- a/.github/workflows/labview-image-contract-certification.yml
+++ b/.github/workflows/labview-image-contract-certification.yml
@@ -23,6 +23,7 @@ on:
         type: choice
         options:
           - hosted-2022
+          - self-hosted-docker-desktop-windows
           - self-hosted-server2019
       isolation_mode:
         description: 'Docker isolation mode'
@@ -172,12 +173,11 @@ jobs:
             throw "Certification classification is ${{ steps.classify.outputs.classification }}"
           }
 
-  certify-self-hosted-server2019:
-    if: ${{ inputs.runner_target == 'self-hosted-server2019' }}
+  certify-self-hosted-docker-desktop-windows:
+    if: ${{ inputs.runner_target == 'self-hosted-docker-desktop-windows' || inputs.runner_target == 'self-hosted-server2019' }}
     runs-on:
       - self-hosted
       - windows
-      - server2019
     timeout-minutes: 240
     env:
       LVIE_ENFORCE_DEDICATED_HOST_CONTRACT: '1'
@@ -187,39 +187,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Ensure self-hosted image availability (preflight)
+      - name: Resolve runner target alias
+        id: lane
         shell: pwsh
         run: |
-          $ErrorActionPreference = 'Stop'
-          $imageTag = '${{ inputs.image_tag }}'.Trim()
-          if ([string]::IsNullOrWhiteSpace($imageTag)) {
-            throw 'workflow input image_tag is empty.'
+          $requested = '${{ inputs.runner_target }}'
+          $effective = $requested
+          $deprecated = 'false'
+          if ($requested -eq 'self-hosted-server2019') {
+            $effective = 'self-hosted-docker-desktop-windows'
+            $deprecated = 'true'
+            Write-Warning "runner_target 'self-hosted-server2019' is deprecated; using '$effective'."
           }
-
-          $dockerServerOs = (& docker version --format '{{.Server.Os}}' 2>$null).Trim()
-          if ($LASTEXITCODE -ne 0) {
-            throw 'Unable to query Docker server mode on self-hosted runner.'
-          }
-          if ($dockerServerOs -ne 'windows') {
-            throw "Self-hosted runner Docker mode must be windows. Current: $dockerServerOs"
-          }
-
-          & docker image inspect $imageTag > $null 2>&1
-          if ($LASTEXITCODE -eq 0) {
-            Write-Host "Image already available locally: $imageTag"
-            exit 0
-          }
-
-          Write-Host "Image not present locally, pulling: $imageTag"
-          & docker pull $imageTag
-          if ($LASTEXITCODE -ne 0) {
-            throw "Unable to pull required image: $imageTag"
-          }
-
-          & docker image inspect $imageTag > $null 2>&1
-          if ($LASTEXITCODE -ne 0) {
-            throw "Pulled image could not be inspected: $imageTag"
-          }
+          "requested_runner_target=$requested" >> $env:GITHUB_OUTPUT
+          "effective_runner_target=$effective" >> $env:GITHUB_OUTPUT
+          "deprecated_alias_used=$deprecated" >> $env:GITHUB_OUTPUT
 
       - name: Runner sanity (dedicated host contract)
         uses: ./.github/actions/runner-bootstrap
@@ -230,16 +212,28 @@ jobs:
           required_labview_years: ${{ env.LVIE_REQUIRED_LABVIEW_YEARS }}
           required_cli_major: ${{ env.LVIE_REQUIRED_CLI_MAJOR }}
 
-      - name: Validate real Server 2019 base
+      - name: Validate Docker Desktop Windows policy
+        id: docker_policy
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $os = Get-CimInstance -ClassName Win32_OperatingSystem
-          $caption = [string]$os.Caption
-          $build = [string]$os.BuildNumber
-          if ($caption -notmatch 'Server' -or $build -ne '17763') {
-            throw "Runner must be a real Server 2019 lane for 2020 eligibility. Caption='$caption' Build='$build'"
+          $dockerJson = (& docker version --format '{{json .}}' 2>$null)
+          if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace([string]$dockerJson)) {
+            throw 'Unable to query docker version. Ensure Docker Desktop is running.'
           }
+
+          $docker = $dockerJson | ConvertFrom-Json -ErrorAction Stop
+          $serverOs = [string]$docker.Server.Os
+          $platformName = [string]$docker.Server.Platform.Name
+          $isDesktopWindows = ($serverOs -eq 'windows') -and ($platformName -like 'Docker Desktop*')
+
+          if (-not $isDesktopWindows) {
+            throw "Self-hosted policy requires Docker Desktop in Windows mode. Server.Os='$serverOs', Platform.Name='$platformName'"
+          }
+
+          "docker_server_os=$serverOs" >> $env:GITHUB_OUTPUT
+          "docker_platform_name=$platformName" >> $env:GITHUB_OUTPUT
+          "is_docker_desktop_windows=true" >> $env:GITHUB_OUTPUT
 
       - name: Run image contract certification
         id: certify
@@ -253,10 +247,13 @@ jobs:
           & .\examples\build-your-own-image\certify-image-contract.ps1 `
             -ContractProfile '${{ inputs.contract_profile }}' `
             -ImageTag '${{ inputs.image_tag }}' `
-            -RunnerTarget '${{ inputs.runner_target }}' `
+            -RunnerTarget '${{ steps.lane.outputs.effective_runner_target }}' `
+            -ExecutionSurface 'native-host' `
             -IsolationMode '${{ inputs.isolation_mode }}' `
             -MaxCliAttempts ([int]'${{ inputs.max_cli_attempts }}') `
             -RepeatRuns ([int]'${{ inputs.repeat_runs }}') `
+            -NativeLabVIEWPath 'C:\Program Files\National Instruments\LabVIEW 2020\LabVIEW.exe' `
+            -NativeBitness '64' `
             -LogRoot $logRoot
 
       - name: Classify certification result
@@ -286,7 +283,10 @@ jobs:
             "### Image Contract Certification",
             "- Contract profile: ${{ inputs.contract_profile }}",
             "- Image tag: ${{ inputs.image_tag }}",
-            "- Runner lane: self-hosted-server2019",
+            "- Runner lane requested: ${{ steps.lane.outputs.requested_runner_target }}",
+            "- Runner lane effective: ${{ steps.lane.outputs.effective_runner_target }}",
+            "- Alias deprecated used: ${{ steps.lane.outputs.deprecated_alias_used }}",
+            "- Docker policy: os=${{ steps.docker_policy.outputs.docker_server_os }}, platform=${{ steps.docker_policy.outputs.docker_platform_name }}",
             "- Classification: $classification",
             "- Summary path: " + ($(if ([string]::IsNullOrWhiteSpace($summaryPath)) { '<not-found>' } else { $summaryPath }))
           ) -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ Run validations in this order and stop at the first failing gate:
 
 ### Track B: 2020 Stabilization
 - Objective: remove non-determinism and satisfy promotion gate.
-- Prefer self-hosted real Server 2019 lane for promotion eligibility.
+- Prefer self-hosted Docker Desktop Windows lane for promotion eligibility.
 - Keep canonical `labview-custom-windows:2020q1-windows` frozen until gate passes.
 
 ## Promotion Guardrail (2020 Canonical Tag)

--- a/Tooling/Assert-ImageCertificationEvidence.ps1
+++ b/Tooling/Assert-ImageCertificationEvidence.ps1
@@ -47,6 +47,7 @@ $requiredTop = @(
     'generated_utc',
     'contract_profile',
     'image_tag',
+    'runner_target',
     'runner_fingerprint',
     'verification_metrics',
     'classification',
@@ -62,7 +63,30 @@ Assert-StringNotBlank -Value ([string]$summary.schema_version) -Name 'schema_ver
 Assert-StringNotBlank -Value ([string]$summary.generated_utc) -Name 'generated_utc'
 Assert-StringNotBlank -Value ([string]$summary.contract_profile) -Name 'contract_profile'
 Assert-StringNotBlank -Value ([string]$summary.image_tag) -Name 'image_tag'
+Assert-StringNotBlank -Value ([string]$summary.runner_target) -Name 'runner_target'
 Assert-StringNotBlank -Value ([string]$summary.classification) -Name 'classification'
+
+$fingerprint = $summary.runner_fingerprint
+$requiredFingerprint = @(
+    'os_caption',
+    'os_version',
+    'os_build',
+    'docker_server_os',
+    'docker_platform_name',
+    'is_docker_desktop_windows'
+)
+foreach ($name in $requiredFingerprint) {
+    Assert-HasProperty -Object $fingerprint -Name $name
+}
+Assert-StringNotBlank -Value ([string]$fingerprint.os_caption) -Name 'runner_fingerprint.os_caption'
+Assert-StringNotBlank -Value ([string]$fingerprint.os_version) -Name 'runner_fingerprint.os_version'
+Assert-StringNotBlank -Value ([string]$fingerprint.os_build) -Name 'runner_fingerprint.os_build'
+Assert-StringNotBlank -Value ([string]$fingerprint.docker_server_os) -Name 'runner_fingerprint.docker_server_os'
+Assert-StringNotBlank -Value ([string]$fingerprint.docker_platform_name) -Name 'runner_fingerprint.docker_platform_name'
+if ($null -eq $fingerprint.is_docker_desktop_windows -or $fingerprint.is_docker_desktop_windows -isnot [bool]) {
+    $actualType = if ($null -eq $fingerprint.is_docker_desktop_windows) { '<null>' } else { $fingerprint.is_docker_desktop_windows.GetType().FullName }
+    throw "runner_fingerprint.is_docker_desktop_windows must be a boolean. Actual type: $actualType"
+}
 
 if (-not [string]::IsNullOrWhiteSpace($ExpectedContractProfile) -and [string]$summary.contract_profile -ne $ExpectedContractProfile) {
     throw "contract_profile mismatch. expected='$ExpectedContractProfile' actual='$($summary.contract_profile)'"

--- a/Tooling/image-cert-summary.schema.json
+++ b/Tooling/image-cert-summary.schema.json
@@ -38,7 +38,8 @@
         "os_version",
         "os_build",
         "docker_server_os",
-        "is_real_server2019"
+        "docker_platform_name",
+        "is_docker_desktop_windows"
       ],
       "properties": {
         "os_caption": {
@@ -52,6 +53,12 @@
         },
         "docker_server_os": {
           "type": "string"
+        },
+        "docker_platform_name": {
+          "type": "string"
+        },
+        "is_docker_desktop_windows": {
+          "type": "boolean"
         },
         "is_real_server2019": {
           "type": "boolean"

--- a/Tooling/image-contract-profiles.json
+++ b/Tooling/image-contract-profiles.json
@@ -7,7 +7,7 @@
       "port_contract_scope": "container-image-contract",
       "notes": "Intentional split-track override. Host-native contract remains 2020/64=3366 in Tooling/labviewcli-port-contract.json.",
       "directory_to_compile": "C:\\Program Files\\National Instruments\\LabVIEW 2020\\examples\\Arrays",
-      "requires_real_server2019": true,
+      "requires_docker_desktop_windows": true,
       "require_port_listener": true,
       "required_repeat_runs": 2
     },
@@ -16,7 +16,7 @@
       "lv_cli_port": "3363",
       "port_contract_scope": "container-image-contract",
       "directory_to_compile": "C:\\Program Files\\National Instruments\\LabVIEW 2026\\examples\\Arrays",
-      "requires_real_server2019": false,
+      "requires_docker_desktop_windows": false,
       "require_port_listener": false,
       "required_repeat_runs": 2
     }

--- a/docs/windows-custom-images-operations.md
+++ b/docs/windows-custom-images-operations.md
@@ -424,9 +424,14 @@ Manual workflow inputs:
 - `max_cli_attempts`
 - `repeat_runs`
 
-For `2020-x64-stabilization`, certification may run on hosted lanes for
-diagnostics, but `promotion_eligible` remains `false` unless runner
-fingerprint indicates a real Server 2019 lane.
+For `2020-x64-stabilization`, promotion eligibility is tied to self-hosted
+Docker Desktop Windows policy checks (`Server.Os=windows` and
+`Server.Platform.Name` starts with `Docker Desktop`).
+
+Migration note:
+
+- The prior real Server 2019 requirement has been replaced by the Docker
+  Desktop Windows requirement for this policy surface.
 
 Profile note:
 
@@ -448,7 +453,7 @@ Comparison procedure (triage discipline):
 ## 2020 Promotion Freeze and Gate (Deferred)
 
 Promotion remains blocked for `labview-custom-windows:2020q1-windows` until
-one real Server 2019 lane passes two fresh runs with all of:
+one self-hosted Docker Desktop Windows lane passes two fresh runs with all of:
 
 - `final_exit_code=0`
 - `contains_minus_350000=false`

--- a/examples/build-your-own-image/verify-lv-cli-masscompile-native.ps1
+++ b/examples/build-your-own-image/verify-lv-cli-masscompile-native.ps1
@@ -1,0 +1,309 @@
+[CmdletBinding()]
+param(
+    [string]$LvYear = '2020',
+    [string]$LabVIEWPath = '',
+    [string]$LvCliPort = '3366',
+    [string]$DirectoryToCompile = '',
+    [int]$MaxCliAttempts = 2,
+    [string]$LogRoot = 'TestResults/agent-logs'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Ensure-Directory {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+        New-Item -Path $Path -ItemType Directory -Force | Out-Null
+    }
+}
+
+function Get-IniKeyValue {
+    param(
+        [Parameter(Mandatory = $true)][string]$IniPath,
+        [Parameter(Mandatory = $true)][string]$Key
+    )
+
+    if (-not (Test-Path -LiteralPath $IniPath -PathType Leaf)) {
+        return $null
+    }
+
+    foreach ($line in Get-Content -LiteralPath $IniPath -ErrorAction Stop) {
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            continue
+        }
+        $trimmed = $line.Trim()
+        if ($trimmed.StartsWith(';') -or $trimmed.StartsWith('#')) {
+            continue
+        }
+        $separator = $trimmed.IndexOf('=')
+        if ($separator -lt 0) {
+            continue
+        }
+        $lineKey = $trimmed.Substring(0, $separator).Trim()
+        if ($lineKey.Equals($Key, [System.StringComparison]::OrdinalIgnoreCase)) {
+            return $trimmed.Substring($separator + 1).Trim()
+        }
+    }
+
+    return $null
+}
+
+function Invoke-MassCompileAttempt {
+    param(
+        [Parameter(Mandatory = $true)][int]$AttemptIndex,
+        [Parameter(Mandatory = $true)][string]$LabVIEWCliPath,
+        [Parameter(Mandatory = $true)][string]$LabVIEWExePath,
+        [Parameter(Mandatory = $true)][string]$CompileDirectory,
+        [Parameter(Mandatory = $true)][string]$Port,
+        [Parameter(Mandatory = $true)][string]$RunRoot
+    )
+
+    $attemptName = "masscompile-attempt{0}" -f $AttemptIndex
+    $attemptLogPath = Join-Path $RunRoot ($attemptName + '.log')
+    $args = @(
+        '-LogToConsole', 'TRUE',
+        '-LabVIEWPath', $LabVIEWExePath,
+        '-OperationName', 'MassCompile',
+        '-DirectoryToCompile', $CompileDirectory,
+        '-PortNumber', $Port,
+        '-Headless'
+    )
+
+    $previousErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = 'Continue'
+        $output = & $LabVIEWCliPath @args 2>&1
+    }
+    finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+
+    $exitCode = if ($null -eq $LASTEXITCODE) { 0 } else { [int]$LASTEXITCODE }
+    $lines = @()
+    foreach ($line in @($output)) {
+        if ($null -eq $line) {
+            continue
+        }
+        $text = [string]$line
+        Write-Host $text
+        $lines += $text
+    }
+    Set-Content -LiteralPath $attemptLogPath -Value $lines -Encoding utf8
+
+    $containsMinus350000 = ($lines -join "`n") -match '-350000'
+    return [pscustomobject]@{
+        AttemptName         = $attemptName
+        ExitCode            = $exitCode
+        LogPath             = $attemptLogPath
+        ContainsMinus350000 = $containsMinus350000
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($LvYear)) {
+    throw 'LvYear must not be empty.'
+}
+if ([string]::IsNullOrWhiteSpace($LabVIEWPath)) {
+    $LabVIEWPath = "C:\Program Files\National Instruments\LabVIEW $LvYear\LabVIEW.exe"
+}
+if ([string]::IsNullOrWhiteSpace($DirectoryToCompile)) {
+    $DirectoryToCompile = "C:\Program Files\National Instruments\LabVIEW $LvYear\examples\Arrays"
+}
+if ($MaxCliAttempts -lt 1) {
+    throw 'MaxCliAttempts must be >= 1.'
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$resolvedLogRoot = if ([System.IO.Path]::IsPathRooted($LogRoot)) { $LogRoot } else { Join-Path $repoRoot $LogRoot }
+Ensure-Directory -Path $resolvedLogRoot
+
+$runTimestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$runLogRoot = Join-Path $resolvedLogRoot ("native-single-run-{0}" -f $runTimestamp)
+Ensure-Directory -Path $runLogRoot
+$diagRoot = Join-Path $runLogRoot 'verify-diag'
+Ensure-Directory -Path $diagRoot
+
+$preflightPath = Join-Path $runLogRoot 'preflight.txt'
+$portStatusPath = Join-Path $diagRoot 'port-status.txt'
+$netBeforePath = Join-Path $diagRoot 'netstat-before-cli.txt'
+$netAfterPath = Join-Path $diagRoot 'netstat-after-cli.txt'
+$processPath = Join-Path $diagRoot 'processes.txt'
+$portConfigPath = Join-Path $diagRoot 'port-config.txt'
+
+$labviewProcess = $null
+$stepHistory = @()
+$portListeningBeforeCli = $false
+$firstAttemptExit = -1
+$secondAttemptExit = $null
+$containsMinus350000 = $false
+$finalExitCode = 1
+$failureMessage = ''
+
+$lvIniPath = Join-Path (Split-Path -Parent $LabVIEWPath) 'LabVIEW.ini'
+$cliIniCandidates = @(
+    'C:\Program Files (x86)\National Instruments\Shared\LabVIEW CLI\LabVIEWCLI.ini',
+    'C:\Program Files\National Instruments\Shared\LabVIEW CLI\LabVIEWCLI.ini'
+)
+$cliIniPath = $cliIniCandidates | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } | Select-Object -First 1
+
+@(
+    "timestamp=$((Get-Date).ToString('o'))",
+    "lv_year=$LvYear",
+    "labview_path=$LabVIEWPath",
+    "lv_cli_port=$LvCliPort",
+    "directory_to_compile=$DirectoryToCompile",
+    "max_cli_attempts=$MaxCliAttempts"
+) | Set-Content -LiteralPath $preflightPath -Encoding ascii
+
+try {
+    if (-not (Test-Path -LiteralPath $LabVIEWPath -PathType Leaf)) {
+        throw "LabVIEW executable not found at $LabVIEWPath"
+    }
+    if (-not (Test-Path -LiteralPath $DirectoryToCompile -PathType Container)) {
+        throw "DirectoryToCompile not found: $DirectoryToCompile"
+    }
+
+    $lvCliCommand = Get-Command -Name LabVIEWCLI -ErrorAction SilentlyContinue
+    if ($null -eq $lvCliCommand) {
+        throw 'LabVIEWCLI is not available on PATH.'
+    }
+
+    $serverTcpEnabled = Get-IniKeyValue -IniPath $lvIniPath -Key 'server.tcp.enabled'
+    $serverTcpPort = Get-IniKeyValue -IniPath $lvIniPath -Key 'server.tcp.port'
+    $defaultPort = if ($null -ne $cliIniPath) { Get-IniKeyValue -IniPath $cliIniPath -Key 'DefaultPortNumber' } else { $null }
+    @(
+        "labview_ini=$lvIniPath",
+        "labview_cli_ini=$cliIniPath",
+        "server.tcp.enabled=$serverTcpEnabled",
+        "server.tcp.port=$serverTcpPort",
+        "DefaultPortNumber=$defaultPort"
+    ) | Set-Content -LiteralPath $portConfigPath -Encoding ascii
+
+    try {
+        $labviewProcess = Start-Process -FilePath $LabVIEWPath -WindowStyle Hidden -PassThru -ErrorAction Stop
+        Start-Sleep -Seconds 10
+    }
+    catch {
+        Write-Warning ("Failed to prelaunch LabVIEW process: " + $_.Exception.Message)
+    }
+
+    $netBefore = netstat -ano
+    Set-Content -LiteralPath $netBeforePath -Value $netBefore -Encoding utf8
+    $listenPattern = ':{0}\s+.*LISTENING' -f [regex]::Escape($LvCliPort)
+    $listenLines = @($netBefore | Select-String -Pattern $listenPattern)
+    $portListeningBeforeCli = $listenLines.Count -gt 0
+    @(
+        "port=$LvCliPort",
+        "listening_count=$($listenLines.Count)",
+        "port_listening_before_cli=$portListeningBeforeCli"
+    ) | Set-Content -LiteralPath $portStatusPath -Encoding ascii
+    if ($listenLines.Count -gt 0) {
+        $listenLines | ForEach-Object { $_.ToString() } | Set-Content -LiteralPath (Join-Path $diagRoot 'port-listening-lines.txt') -Encoding ascii
+    }
+
+    $attempt1 = Invoke-MassCompileAttempt `
+        -AttemptIndex 1 `
+        -LabVIEWCliPath $lvCliCommand.Source `
+        -LabVIEWExePath $LabVIEWPath `
+        -CompileDirectory $DirectoryToCompile `
+        -Port $LvCliPort `
+        -RunRoot $runLogRoot
+    $stepHistory += [pscustomobject]@{ step = $attempt1.AttemptName; exit_code = $attempt1.ExitCode; log_path = $attempt1.LogPath }
+    $firstAttemptExit = [int]$attempt1.ExitCode
+    $containsMinus350000 = [bool]$attempt1.ContainsMinus350000
+
+    if ($attempt1.ExitCode -ne 0 -and $attempt1.ContainsMinus350000 -and $MaxCliAttempts -ge 2) {
+        Start-Sleep -Seconds 10
+        $attempt2 = Invoke-MassCompileAttempt `
+            -AttemptIndex 2 `
+            -LabVIEWCliPath $lvCliCommand.Source `
+            -LabVIEWExePath $LabVIEWPath `
+            -CompileDirectory $DirectoryToCompile `
+            -Port $LvCliPort `
+            -RunRoot $runLogRoot
+        $stepHistory += [pscustomobject]@{ step = $attempt2.AttemptName; exit_code = $attempt2.ExitCode; log_path = $attempt2.LogPath }
+        $secondAttemptExit = [int]$attempt2.ExitCode
+        if ($attempt2.ContainsMinus350000) {
+            $containsMinus350000 = $true
+        }
+    }
+
+    if ($null -ne $secondAttemptExit) {
+        $finalExitCode = [int]$secondAttemptExit
+    }
+    else {
+        $finalExitCode = [int]$firstAttemptExit
+    }
+}
+catch {
+    $failureMessage = $_.Exception.Message
+}
+finally {
+    $netAfter = netstat -ano
+    Set-Content -LiteralPath $netAfterPath -Value $netAfter -Encoding utf8
+    Get-Process | Sort-Object ProcessName | Select-Object ProcessName, Id, Path | Out-File -FilePath $processPath -Encoding utf8
+
+    $tempRoot = Join-Path $diagRoot 'lvtemporary'
+    Ensure-Directory -Path $tempRoot
+    Get-ChildItem -LiteralPath ([System.IO.Path]::GetTempPath()) -Filter 'lvtemporary_*.log' -File -ErrorAction SilentlyContinue | ForEach-Object {
+        Copy-Item -LiteralPath $_.FullName -Destination (Join-Path $tempRoot $_.Name) -Force
+    }
+
+    $userLogRoot = Join-Path $diagRoot 'labview-user-logs'
+    Ensure-Directory -Path $userLogRoot
+    $userTemp = [System.IO.Path]::GetTempPath()
+    Get-ChildItem -LiteralPath $userTemp -File -ErrorAction SilentlyContinue | Where-Object {
+        $_.Name -like 'LabVIEW*' -or $_.Name -like 'LabVIEWCLI*'
+    } | Select-Object -First 200 | ForEach-Object {
+        Copy-Item -LiteralPath $_.FullName -Destination (Join-Path $userLogRoot $_.Name) -Force
+    }
+
+    if (Test-Path -LiteralPath $lvIniPath -PathType Leaf) {
+        Copy-Item -LiteralPath $lvIniPath -Destination (Join-Path $diagRoot 'LabVIEW.ini') -Force
+    }
+    if (-not [string]::IsNullOrWhiteSpace($cliIniPath) -and (Test-Path -LiteralPath $cliIniPath -PathType Leaf)) {
+        Copy-Item -LiteralPath $cliIniPath -Destination (Join-Path $diagRoot 'LabVIEWCLI.ini') -Force
+    }
+
+    if ($null -ne $labviewProcess) {
+        try {
+            Stop-Process -Id $labviewProcess.Id -Force -ErrorAction SilentlyContinue
+        }
+        catch {
+            Write-Warning ("Unable to stop prelaunched LabVIEW process id $($labviewProcess.Id).")
+        }
+    }
+
+    $summary = [ordered]@{
+        timestamp_utc             = (Get-Date).ToUniversalTime().ToString('o')
+        execution_surface         = 'native-host'
+        lv_year                   = $LvYear
+        labview_path              = $LabVIEWPath
+        lv_cli_port               = $LvCliPort
+        directory_to_compile      = $DirectoryToCompile
+        max_cli_attempts          = $MaxCliAttempts
+        port_listening_before_cli = $portListeningBeforeCli
+        first_attempt_exit        = $firstAttemptExit
+        second_attempt_exit       = $secondAttemptExit
+        contains_minus_350000     = $containsMinus350000
+        final_exit_code           = $finalExitCode
+        run_succeeded             = ($finalExitCode -eq 0 -and -not $containsMinus350000)
+        failure_message           = $failureMessage
+        logs_path                 = $runLogRoot
+        step_history              = $stepHistory
+    }
+
+    $summaryPath = Join-Path $runLogRoot 'summary.json'
+    $summary | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $summaryPath -Encoding ascii
+    Write-Host "summary_path=$summaryPath"
+}
+
+if ($finalExitCode -ne 0 -or $containsMinus350000) {
+    if ([string]::IsNullOrWhiteSpace($failureMessage)) {
+        $failureMessage = "Native MassCompile verification failed. See logs at $runLogRoot"
+    }
+    throw $failureMessage
+}
+
+Write-Host 'Native MassCompile verification succeeded.'


### PR DESCRIPTION
## Summary
Replace the 2020 stabilization eligibility environment requirement from real Server 2019 to Docker Desktop in Windows mode on self-hosted lanes.

## Included changes
- profile gate key migrated to equires_docker_desktop_windows
- certify-image-contract.ps1 eligibility logic migrated to Docker Desktop Windows checks
- schema + evidence assertion updated for Docker Desktop fingerprint fields
- self-hosted workflow target canonicalized to self-hosted-docker-desktop-windows
- deprecated alias self-hosted-server2019 retained for compatibility
- native verifier script added for self-hosted native surface
- docs + AGENTS policy updated

## Notes
- Hosted lane behavior for 2026 remains unchanged.
- No retag/publish automation changes in this PR.

Refs #1